### PR TITLE
fix broken link to download page

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -10,7 +10,7 @@ draft = false
 
 hexxed is a puzzle game designed by scientists to study how we solve problems. By playing, you will contribute to a global experiment seeking to model the human creative process with unprecedented depth and clarity.
 
-[**Download hexxed now!**](#Download)
+[**Download hexxed now!**](#download)
 
 
 


### PR DESCRIPTION
fixes minor bug that used upper-case `D` to spell `Download` in the `Download hexxed now!` hyperlink, resulting in broken link. 