### PR TITLE
add a link to a new page for media coverage

### DIFF
--- a/content/press.md
+++ b/content/press.md
@@ -1,0 +1,3 @@
+# Press Coverage
+
+* [![Berkeley News December 14th 2020]()](https://news.berkeley.edu/2020/12/14/neuroscientists-tap-gamers-to-learn-how-people-problem-solve/)

--- a/docs/index.html
+++ b/docs/index.html
@@ -46,6 +46,8 @@
                   <li><a href="#research">Research</a></li>
                 
                   <li><a href="#download">Download</a></li>
+		      
+		  <li><a href="#press">Press Coverage</a></li>
                 
               </ul>
             </nav>


### PR DESCRIPTION
Thought it would be nice to have a link to the "press releases" or other media content (e.g., tweet rolls etc.) on the website... @synapticleft also suggested putting the link on the app stores... anyways, here's a pull request to get the ball rolling on this... 

could rename it to "News" or "Media" or something else too..